### PR TITLE
Change Target Time within ones employment

### DIFF
--- a/migrations/20170321150942-story-135-user-target-times.js
+++ b/migrations/20170321150942-story-135-user-target-times.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20170321150942-story-135-user-target-times-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20170321150942-story-135-user-target-times-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
+++ b/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
@@ -1,0 +1,130 @@
+/* create new table for target times */
+CREATE TABLE user_target_times AS
+  SELECT
+    usr_id AS utt_usr_id,
+    COALESCE(usr_start_timetracking, usr_employment_start, '2012-01-01') AS utt_start,
+    'infinity'::date AS utt_end,
+    usr_target_time AS utt_target_time
+  FROM users;
+
+
+
+/* adjsut constraints */
+ALTER TABLE user_target_times
+  ADD CONSTRAINT utt_overlapping_times EXCLUDE USING GIST (utt_usr_id WITH =, TSRANGE(utt_start, utt_end) WITH &&),
+  ADD CONSTRAINT utt_check_end_bigger_start CHECK(utt_end > utt_start),
+  ADD PRIMARY KEY (utt_usr_id, utt_start, utt_end),
+  ALTER utt_target_time SET NOT NULL,
+  ALTER utt_end SET DEFAULT 'infinity';
+
+
+ALTER TABLE users
+  DROP COLUMN usr_target_time,
+  DROP COLUMN usr_start_timetracking;
+
+
+
+/* introduce new function to get start date for user since it's used multiple times */
+CREATE OR REPLACE FUNCTION user_get_start_date (id INTEGER) RETURNS DATE
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        DATE;
+BEGIN
+    BEGIN
+    SELECT COALESCE(
+        (
+          SELECT MIN(utt_start) earliest_start
+          FROM user_target_times
+          WHERE utt_usr_id = id
+        ),
+        usr_employment_start,
+        '2012-01-01'
+    )
+    INTO STRICT target
+    FROM users WHERE usr_id = id;
+
+    EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+      RAISE EXCEPTION 'user % not found', id;
+  END;
+
+  RETURN target;
+END
+$$;
+
+
+
+/* adjust function to new target times feature */
+CREATE OR REPLACE FUNCTION user_get_target_time (id INTEGER, day_date DATE) RETURNS interval
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  target        INTERVAL;
+  start_date    DATE;
+BEGIN
+
+  -- done explicitly to check if user exists, otherwise function doesn't get called due to the optimizer
+  SELECT user_get_start_date(id)
+  INTO   STRICT start_date;
+
+
+  SELECT CASE
+         WHEN day_date >= start_date  AND EXTRACT(ISODOW FROM day_date) < 6
+           THEN utt_target_time/5
+         ELSE '00:00:00'::INTERVAL
+         END
+  INTO   target
+  FROM   user_target_times
+  WHERE  utt_usr_id = id
+  AND    COALESCE(TSRANGE(utt_start, utt_end, '[)') @> day_date::TIMESTAMP, TRUE);
+
+
+  RETURN COALESCE(target, '00:00:00'::INTERVAL);
+END
+$$;
+
+
+/* adjust function to new feature */
+CREATE OR REPLACE FUNCTION user_worktime(id INTEGER, due_date DATE)
+  RETURNS TABLE(
+    uw_date          DATE,
+    uw_year          INTEGER,
+    uw_week          INTEGER,
+    uw_dow           INTEGER,
+    uw_diff_per_day  INTERVAL,
+    uw_new           INTERVAL,
+    uw_sum_per_day   INTERVAL,
+    uw_diff_per_week INTERVAL,
+    uw_sum_per_week  INTERVAL,
+    uw_sum_overall   INTERVAL
+  ) LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  from_date         DATE;
+BEGIN
+  -- done explicitly to check if user exists, otherwise function doesn't get called due to the optimizer
+  SELECT user_get_start_date(id)
+  INTO   STRICT from_date;
+
+  RETURN QUERY WITH days_raw AS (
+      SELECT    s::DATE,
+        EXTRACT(YEAR FROM s::DATE)::INTEGER yy,
+        EXTRACT(WEEK FROM s::DATE)::INTEGER ww,
+        EXTRACT(ISODOW FROM s::DATE)::INTEGER dow,
+        (SUM(COALESCE(per_duration, '00:00:00') - COALESCE(per_break, '00:00:00')) - SUM(DISTINCT user_get_target_time(id, s::DATE))) sum_total_day,
+        SUM(DISTINCT user_get_target_time(id, s::DATE))
+      FROM      generate_series(from_date, due_date, '1 day'::interval) s
+        LEFT join days ON (day_date = s AND day_usr_id = id)
+        LEFT JOIN periods ON (day_id = per_day_id)
+      GROUP BY  s
+  )
+  SELECT   *,
+    SUM(sum_total_day) OVER (ORDER BY s) sum_per_day,
+    CASE WHEN dow = 7 THEN SUM(sum_total_day) OVER (PARTITION BY yy, ww ORDER BY yy, ww) ELSE NULL END diff_per_week,
+    CASE WHEN dow = 7 THEN SUM(sum_total_day) OVER (ORDER BY s) ELSE NULL END sum_per_week,
+    SUM(sum_total_day) OVER () sum_overall
+  FROM     days_raw
+  ORDER BY s;
+END;
+$$;

--- a/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
+++ b/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
@@ -95,7 +95,6 @@ CREATE OR REPLACE FUNCTION user_worktime(id INTEGER, due_date DATE)
     uw_week          INTEGER,
     uw_dow           INTEGER,
     uw_diff_per_day  INTERVAL,
-    uw_new           INTERVAL,
     uw_sum_per_day   INTERVAL,
     uw_diff_per_week INTERVAL,
     uw_sum_per_week  INTERVAL,
@@ -114,8 +113,7 @@ BEGIN
         EXTRACT(YEAR FROM s::DATE)::INTEGER yy,
         EXTRACT(WEEK FROM s::DATE)::INTEGER ww,
         EXTRACT(ISODOW FROM s::DATE)::INTEGER dow,
-        (SUM(COALESCE(per_duration, '00:00:00') - COALESCE(per_break, '00:00:00')) - SUM(DISTINCT user_get_target_time(id, s::DATE))) sum_total_day,
-        SUM(DISTINCT user_get_target_time(id, s::DATE))
+        (SUM(COALESCE(per_duration, '00:00:00') - COALESCE(per_break, '00:00:00')) - SUM(DISTINCT user_get_target_time(id, s::DATE))) sum_total_day
       FROM      generate_series(from_date, due_date, '1 day'::interval) s
         LEFT join days ON (day_date = s AND day_usr_id = id)
         LEFT JOIN periods ON (day_id = per_day_id)

--- a/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
+++ b/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
@@ -52,6 +52,7 @@ BEGIN
   RETURN target;
 END
 $$;
+COMMENT ON FUNCTION user_get_start_date (INTEGER) IS 'get first date for a user relevant for ttrack.';
 
 
 
@@ -83,6 +84,7 @@ BEGIN
   RETURN COALESCE(target, '00:00:00'::INTERVAL);
 END
 $$;
+COMMENT ON FUNCTION user_get_target_time (INTEGER, DATE) IS 'get the calculated target time for a user on a given date.';
 
 
 /* adjust function to new feature */
@@ -128,3 +130,4 @@ BEGIN
   ORDER BY s;
 END;
 $$;
+COMMENT ON FUNCTION user_worktime (INTEGER, DATE) IS 'calculate the overall working hours for a user until a given date.';

--- a/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
+++ b/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
@@ -131,6 +131,38 @@ $$;
 COMMENT ON FUNCTION user_worktime (INTEGER, DATE) IS 'calculate the overall working hours for a user until a given date.';
 
 
+-- calculates carry time for given user
+CREATE OR REPLACE FUNCTION user_calculate_carry_time(id INTEGER, due_date DATE)
+  RETURNS TABLE(
+    uw_date_from  DATE,
+    uw_due_date   DATE,
+    uw_carry_time INTERVAL
+  ) LANGUAGE plpgsql STABLE
+AS $$
+DECLARE
+  from_date  DATE;
+BEGIN
+  -- start with either start_timetracking, employment start or fallback
+  SELECT
+    LEAST(due_date, user_get_start_date(id))
+  INTO STRICT from_date
+  FROM users
+  WHERE usr_id = id;
+
+  RETURN QUERY SELECT
+                 from_date,
+                 due_date,
+                 SUM(sum_total_day)
+               FROM (
+                      SELECT
+                        (SUM(COALESCE(per_duration, '00:00:00') - COALESCE(per_break, '00:00:00')) - SUM(DISTINCT user_get_target_time(id, s :: DATE))) sum_total_day
+                      FROM generate_series(from_date, GREATEST(due_date, from_date), '1 day' :: INTERVAL) s
+                        LEFT JOIN days ON (day_date = s AND day_usr_id = id)
+                        LEFT JOIN periods ON (day_id = per_day_id)
+                      GROUP BY s :: DATE
+                    ) foo;
+END;
+$$;
 
 /* introduce new function to get start date for user since it's used multiple times */
 CREATE OR REPLACE FUNCTION user_add_new_target_time (id INTEGER, startdate DATE, target INTERVAL) RETURNS VOID

--- a/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
+++ b/migrations/sqls/20170321150942-story-135-user-target-times-up.sql
@@ -192,9 +192,9 @@ BEGIN
 
     -- update days
     -- update full days
-    UPDATE days SET day_target_time = target/5 WHERE day_usr_id = id AND day_date > startdate AND day_target_time = old_target/5;
+    UPDATE days SET day_target_time = target/5 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/5;
     -- update half days
-    UPDATE days SET day_target_time = target/10 WHERE day_usr_id = id AND day_date > startdate AND day_target_time = old_target/10;
+    UPDATE days SET day_target_time = target/10 WHERE day_usr_id = id AND day_date >= startdate AND day_target_time = old_target/10;
 
     -- update periods?
     -- update full periods
@@ -202,7 +202,7 @@ BEGIN
       FROM days
     WHERE day_id = per_day_id
     AND day_usr_id = id
-    AND day_date > startdate
+    AND day_date >= startdate
     AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
     AND per_duration = old_target/5;
 
@@ -211,7 +211,7 @@ BEGIN
       FROM days
     WHERE day_id = per_day_id
     AND day_usr_id = id
-    AND day_date > startdate
+    AND day_date >= startdate
     AND per_pty_id IN ('Vacation', 'Sick', 'Nursing', 'Holiday')
     AND per_duration = old_target/10;
 

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -13,7 +13,12 @@ const days = sql.define({
 
 const users = sql.define({
     name: 'users',
-    columns: ['usr_id', 'usr_firstname', 'usr_lastname', 'usr_email', 'usr_target_time', 'usr_employment_start', 'usr_employment_end', 'usr_start_timetracking'],
+    columns: ['usr_id', 'usr_firstname', 'usr_lastname', 'usr_email', 'usr_employment_start', 'usr_employment_end'],
+});
+
+const userTargetTimes = sql.define({
+    name: 'user_target_times',
+    columns: ['utt_usr_id', 'utt_start', 'utt_end', 'utt_target_time'],
 });
 
 const periodTypes = sql.define({
@@ -49,6 +54,7 @@ module.exports = {
     periods,
     days,
     users,
+    userTargetTimes,
     periodTypes,
     query,
 };

--- a/src/server/resources/period.js
+++ b/src/server/resources/period.js
@@ -1,7 +1,5 @@
 require('moment-duration-format');
 const Q = require('q');
-const dba = require('../db');
-const util = require('../../common/util');
 const moment = require('moment');
 const _ = require('lodash');
 const User = require('./user');
@@ -12,50 +10,25 @@ const User = require('./user');
  * @param db the db object
  * @param date the date, format YYYY-MM-DD
  * @param user the user
+ * @param target the users target time for that day
  * @returns {*} promise
  */
-function fetchDayIdForUser(db, date, user) {
-    return dba.query(db, 'SELECT day_id FROM days WHERE day_date = $1 AND day_usr_id = $2', [date, user.usr_id])
+function fetchDayIdForUser(db, date, user, target) {
+    return db.query('SELECT day_id FROM days WHERE day_date = $1 AND day_usr_id = $2', [date, user.usr_id])
         .then((result) => {
             if (result.rows.length) {
                 return result.rows[0].day_id;
             }
 
-            // todo use timehseets getTargetTime
-            const day = util.getDayDuration(moment.duration(user.usr_target_time));
-
-            const defaultWeekdayWorktime = {
-                hours: day.hours(),
-                minutes: day.minutes(),
-            };
-
-            console.info('create new day', date);
-            if (moment(date).isoWeekday() < 6) {
-                console.info('with', defaultWeekdayWorktime);
-                return createDayIdForUser(db, date, defaultWeekdayWorktime, user.usr_id);
-            }
-
-            return createDayIdForUser(db, date, { hours: 0 }, user.usr_id);
+            const queryString = 'INSERT INTO days VALUES (default, $1, $2, $3) RETURNING day_id';
+            return db.query(
+                queryString,
+                [date, user.usr_id, target]).then(res => res.rows[0].day_id);
         });
 }
 
-function createDayIdForUser(db, date, interval, userId) {
-    const hours = parseInt(interval.hours, 10) || 0;
-    const minutes = parseInt(interval.minutes, 10) || 0;
-
-    // ugly hack because stupid query builder is buggy when converting interval object to database interval string himself,
-    // and turns {hours: 7, minutes: 42} into interval '7 minutes, 42 seconds' ...
-    let queryString = "INSERT INTO days (day_date, day_usr_id, day_target_time) VALUES ($1, $2, interval '$3 hours, $4 minutes') RETURNING day_id";
-    queryString = queryString.replace('$3', hours);
-    queryString = queryString.replace('$4', minutes);
-
-    return dba.query(db,
-        queryString,
-        [date, userId]).then(result => result.rows[0].day_id);
-}
-
 function fetchPeriodTypes(db) {
-    return dba.query(db, 'SElECT * FROM period_types').then((result) => {
+    return db.query('SElECT * FROM period_types').then((result) => {
         const map = {};
         result.rows.forEach((row) => {
             map[row.pty_name] = row.pty_id;
@@ -86,34 +59,41 @@ function preparePeriodForApiResponse(periodData) {
 module.exports = {
     post(pg, userId, postData, cb) {
         pg((db) => {
-            User.get(pg, userId, (user) => {
-                Q.all([
-                    fetchPeriodTypes(db),
-                    fetchDayIdForUser(db, postData.date, user),
-                ]).spread((types, dayId) => {
-                    const data = postData;
-                    // TODO: check if pty_id is valid type if defined
-                    if (data.per_pty_id === undefined) {
-                        data.per_pty_id = types.Arbeitszeit;
-                    }
-
-                    if (data.per_start) {
-                        data.per_stop = data.per_stop ? convertToTime(data.per_stop) : null;
-                        data.per_start = convertToTime(data.per_start);
-                        data.per_break = convertToTime(data.per_break);
-                        return dba.query(db,
-                            'INSERT INTO periods (per_start, per_stop, per_break, per_comment, per_day_id, per_pty_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
-                            [data.per_start, data.per_stop, data.per_break, data.per_comment, dayId, data.per_pty_id]);
-                    }
-
-                    data.per_duration = convertToTime(data.per_duration);
-                    return dba.query(db,
-                        'INSERT INTO periods (per_duration, per_comment, per_day_id, per_pty_id) VALUES ($1, $2, $3, $4) RETURNING *',
-                        [data.per_duration, data.per_comment, dayId, data.per_pty_id]);
-                }).then((result) => {
-                    cb(preparePeriodForApiResponse(result.rows[0]));
-                }).done();
+            const userPromise = Q.promise((resolve) => {
+                User.get(pg, userId, resolve);
             });
+            const targetPromise = Q.promise((resolve) => {
+                User.getTargetTime(pg, userId, postData.date, resolve);
+            });
+            Q.all([userPromise, targetPromise])
+                .spread((user, target) => {
+                    Q.all([
+                        fetchPeriodTypes(db),
+                        fetchDayIdForUser(db, postData.date, user, target),
+                    ]).spread((types, dayId) => {
+                        const data = postData;
+                        // TODO: check if pty_id is valid type if defined
+                        if (data.per_pty_id === undefined) {
+                            data.per_pty_id = types.Arbeitszeit;
+                        }
+
+                        if (data.per_start) {
+                            data.per_stop = data.per_stop ? convertToTime(data.per_stop) : null;
+                            data.per_start = convertToTime(data.per_start);
+                            data.per_break = convertToTime(data.per_break);
+                            return db.query(
+                                'INSERT INTO periods (per_start, per_stop, per_break, per_comment, per_day_id, per_pty_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *',
+                                [data.per_start, data.per_stop, data.per_break, data.per_comment, dayId, data.per_pty_id]);
+                        }
+
+                        data.per_duration = convertToTime(data.per_duration);
+                        return db.query(
+                            'INSERT INTO periods (per_duration, per_comment, per_day_id, per_pty_id) VALUES ($1, $2, $3, $4) RETURNING *',
+                            [data.per_duration, data.per_comment, dayId, data.per_pty_id]);
+                    }).then((result) => {
+                        cb(preparePeriodForApiResponse(result.rows[0]));
+                    }).done();
+                });
         });
     },
     put(pg, userId, putData, cb) {
@@ -132,13 +112,13 @@ module.exports = {
                     data.per_stop = data.per_stop ? convertToTime(data.per_stop) : null;
                     data.per_start = convertToTime(data.per_start);
                     data.per_break = convertToTime(data.per_break);
-                    return dba.query(db,
+                    return db.query(
                         'UPDATE periods SET per_start = $1, per_stop = $2, per_break = $3, per_duration = NULL, per_comment = $4, per_pty_id = $5 WHERE per_id = $6 RETURNING *',
                         [data.per_start, data.per_stop, data.per_break, data.per_comment, data.per_pty_id, data.per_id]);
                 }
 
                 data.per_duration = convertToTime(data.per_duration);
-                return dba.query(db,
+                return db.query(
                     'UPDATE periods SET per_duration = $1, per_comment = $2, per_pty_id = $3, per_start = NULL, per_stop = NULL, per_break = NULL WHERE per_id = $4 RETURNING *',
                     [data.per_duration, data.per_comment, data.per_pty_id, data.per_id]);
             }).then((result) => {

--- a/src/server/resources/timesheet.js
+++ b/src/server/resources/timesheet.js
@@ -151,15 +151,6 @@ function fetchPeriodTypes(client) {
     return db.query(client, periodTypeQuery).then(_.property('rows'));
 }
 
-function fetchUserStart(client, userId) {
-    const query = 'SELECT * FROM user_get_start_date($1)';
-
-    return db.query(client, query, [userId]).then((result) => {
-        const rows = result.rows;
-        return moment(rows[0].user_get_start_date);
-    });
-}
-
 function createMissingHolidays(pg, dateRange, user, start, existingHolidays, holidayPeriodTypeId) {
     const employmentEnd = moment(user.usr_employment_end);
 
@@ -213,7 +204,9 @@ function getTimesheetForTimeRange(pg, client, user, dateRange, cb) {
     const periodTypesPromise = fetchPeriodTypes(client);
 
     // get start for user
-    const userStartPromise = fetchUserStart(client, userId);
+    const userStartPromise = Q.promise((resolve) => {
+        User.getStartDate(pg, userId, resolve);
+    });
 
     Q.all([holidayPromise, periodTypePromise, periodTypesPromise, userStartPromise])
         .spread(

--- a/src/server/resources/user.js
+++ b/src/server/resources/user.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 module.exports = {
     list(pg, cb) {
         pg((db) => {
@@ -32,6 +34,21 @@ module.exports = {
                     return console.error('error running select query', err);
                 }
                 cb(result.rows[0].user_get_target_time);
+                return true;
+            });
+        });
+    },
+    // get Users TargetTime for a specific date from the database
+    getStartDate(pg, userId, cb) {
+        pg((db) => {
+            const query = 'SELECT * FROM user_get_start_date($1)';
+
+            return db.query(query, [userId], (err, result) => {
+                if (err) {
+                    return console.error('error running select query', err);
+                }
+                const rows = result.rows;
+                cb(moment(rows[0].user_get_start_date));
                 return true;
             });
         });


### PR DESCRIPTION
At the moment there is only one target time for a given user.

And that cannot be changed without compromising the history. It is needed that the time changes within ones work life. (Because they worked only 20 hours a week and upgraded to 30 hours ...)

This pr implements the feature so user can have multiple target times in their worklife.